### PR TITLE
Patch `writef16` and `writef32` not working for values very close to powers of two

### DIFF
--- a/default.project.json
+++ b/default.project.json
@@ -7,12 +7,6 @@
 			"bitbuffer": {
 				"$path": "src"
 			}
-		},
-
-		"ServerStorage": {
-			"tests": {
-				"$path": "tests"
-			}
 		}
 	}
 }

--- a/lune/generate.luau
+++ b/lune/generate.luau
@@ -9,7 +9,7 @@ table.insert(output, [[--!native
 --!strict
 
 -- stylua: ignore start
--- @diagnostic disable: undefined-type
+---@diagnostic disable: undefined-type
 
 local readu8 = buffer.readu8
 local readu16 = buffer.readu16

--- a/lune/main/float.luau
+++ b/lune/main/float.luau
@@ -1,53 +1,5 @@
 local Snippet = require("../Snippet.luau")
 
-local READ_TEMPALTE = [[if offset % 8 == 0 then
-	return buffer.readf<WIDTH>(b, offset // 8)
-end
-
-local mantissa = bitbuffer.readu<MANTISSA_WIDTH>(b, offset)
-local exponent = bitbuffer.readu<EXPONENT_WIDTH>(b, offset + <MANTISSA_WIDTH>)
-local sign = bitbuffer.readu1(b, offset + <MANTISSA_EXPONENT_WIDTH>) == 1
-
-if mantissa == 0 and exponent == <EXPONENT_MAX> then
-	return if sign then -math.huge else math.huge
-elseif mantissa == 1 and exponent == <EXPONENT_MAX> then
-	return 0 / 0
-elseif mantissa == 0 and exponent == 0 then
-	return 0
-else
-	mantissa = if exponent == 0
-		then mantissa / <SUBNORMAL>
-		else mantissa / <NORMAL> + 0.5
-
-	local value = math.ldexp(mantissa, exponent - <EXPONENT_BIAS>)
-	return if sign then -value else value
-end]]
-
-local WRITE_TEMPLATE = [[if offset % 8 == 0 then
-	buffer.writef<WIDTH>(b, offset // 8, value)
-	return
-end
-
-local mantissa, exponent, sign = 0, 0, 0
-if math.abs(value) > <MAX_VALUE> then
-	exponent, sign = <EXPONENT_MAX>, if value < 0 then 1 else 0
-elseif value ~= value then
-	mantissa, exponent, sign = 1, <EXPONENT_MAX>, 1
-elseif value ~= 0 then
-	mantissa, exponent = math.frexp(value)
-	exponent += <EXPONENT_BIAS>
-
-	mantissa = math.round(if exponent <= 0
-		then math.abs(mantissa) * <SUBNORMAL> / math.ldexp(1, math.abs(exponent))
-		else math.abs(mantissa) * <NORMAL>)
-	exponent = math.max(exponent, 0)
-	sign = if value < 0 then 1 else 0
-end
-
-bitbuffer.writeu<MANTISSA_WIDTH>(b, offset, mantissa)
-bitbuffer.writeu<EXPONENT_WIDTH>(b, offset + <MANTISSA_WIDTH>, exponent)
-bitbuffer.writeu1(b, offset + <MANTISSA_EXPONENT_WIDTH>, sign)]]
-
 local FLOAT_WIDTHS = {
 	[16] = { mantissa = 10, exponent = 5, name = "Half-precision IEEE 754 number" },
 	[32] = { mantissa = 23, exponent = 8, name = "Single-precision IEEE 754 number" },
@@ -66,18 +18,47 @@ local function generateRead()
 
 		local body = Snippet.new()
 
-		local content = READ_TEMPALTE:gsub("<MANTISSA_WIDTH>", mantissaWidth)
-			:gsub("<EXPONENT_WIDTH>", exponentWidth)
-			:gsub("<MANTISSA_EXPONENT_WIDTH>", mantissaWidth + exponentWidth)
-			:gsub("<EXPONENT_MAX>", `0b{string.rep("1", exponentWidth)}`)
-			:gsub("<EXPONENT_BIAS>", 2 ^ (exponentWidth - 1) - 2)
-			:gsub("<SUBNORMAL>", tohex(2 ^ mantissaWidth))
-			:gsub("<NORMAL>", tohex(2 ^ (mantissaWidth + 1)))
-			:gsub("<WIDTH>", width)
+		local exponentMax = `0b{string.rep("1", exponentWidth)}`
+		local exponentBias = 2 ^ (exponentWidth - 1) - 2
 
-		body:Push("--- Reads a ", componentWidths.name)
-		body:Push("function bitbuffer.readf", width, "(b: buffer, offset: number): number")
-		body:Push(content):Indent()
+		if width == 32 or width == 64 then
+			body:Push("\tif offset % 8 == 0 then")
+			body:Push("\t\treturn buffer.readf", width, "(b, offset // 8)")
+			body:Push("\tend\n")
+		end
+
+		-- Read each component
+		body:Push("local mantissa = bitbuffer.readu", mantissaWidth, "(b, offset)")
+		body:Push("local exponent = bitbuffer.readu", exponentWidth, "(b, offset + ", mantissaWidth, ")")
+		body:Push("local sign = bitbuffer.readu1(b, offset + ", mantissaWidth + exponentWidth, ") == 1\n")
+
+		-- Handle infinity
+		body:Push("if mantissa == 0 and exponent == ", exponentMax, " then")
+		body:Push("\treturn if sign then -math.huge else math.huge")
+
+		-- Handle NaN
+		body:Push("elseif mantissa == 1 and exponent == ", exponentMax, " then")
+		body:Push("\treturn 0 / 0")
+
+		-- Handle 0
+		body:Push("elseif mantissa == 0 and exponent == 0 then")
+		body:Push("\treturn 0")
+
+		-- Handle everything else
+		body:Push("else")
+		body:Push("\tmantissa = if exponent == 0")
+		body:Push("\t\tthen mantissa / ", tohex(2 ^ mantissaWidth))
+		body:Push("\t\telse mantissa / ", tohex(2 ^ (mantissaWidth + 1)), " + 0.5\n")
+
+		body:Push("\tlocal value = math.ldexp(mantissa, exponent - ", exponentBias, ")")
+		body:Push("	return if sign then -value else value")
+		body:Push("end")
+
+		body:Indent()
+
+		body:Insert(1, "--- Reads a ", componentWidths.name)
+		body:Insert(2, "function bitbuffer.readf", width, "(b: buffer, offset: number): number")
+
 		body:Push("end")
 
 		table.insert(output, tostring(body))
@@ -88,25 +69,69 @@ end
 local function generateWrite()
 	local output = {}
 	for _, width in { 16, 32, 64 } do
-		local componentWidths = FLOAT_WIDTHS[width]
-		local mantissaWidth, exponentWidth = componentWidths.mantissa, componentWidths.exponent
+		local floatData = FLOAT_WIDTHS[width]
+		local mantissaWidth, exponentWidth = floatData.mantissa, floatData.exponent
 
 		local body = Snippet.new()
 
-		local content = WRITE_TEMPLATE
-			:gsub("<MAX_VALUE>", math.ldexp((2 - 2 ^ -mantissaWidth), (2 ^ (exponentWidth - 1) - 1)))
-			:gsub("<MANTISSA_WIDTH>", mantissaWidth)
-			:gsub("<EXPONENT_WIDTH>", exponentWidth)
-			:gsub("<MANTISSA_EXPONENT_WIDTH>", mantissaWidth + exponentWidth)
-			:gsub("<EXPONENT_MAX>", `0b{string.rep("1", exponentWidth)}`)
-			:gsub("<EXPONENT_BIAS>", 2 ^ (exponentWidth - 1) - 2)
-			:gsub("<SUBNORMAL>", tohex(2 ^ mantissaWidth))
-			:gsub("<NORMAL>", tohex(2 ^ (mantissaWidth + 1)))
-			:gsub("<WIDTH>", width)
+		local exponentMax = `0b{string.rep("1", exponentWidth)}`
+		local exponentBias = 2 ^ (exponentWidth - 1) - 2
 
-		body:Push("--- Writes a ", componentWidths.name)
-		body:Push("function bitbuffer.writef", width, "(b: buffer, offset: number, value: number)")
-		body:Push(content):Indent()
+		-- Handle byte aligned cases when applicable
+		if width == 32 or width == 64 then
+			body:Push("if offset % 8 == 0 then")
+			body:Push("\tbuffer.writef", width, "(b, offset // 8, value)")
+			body:Push("\treturn")
+			body:Push("end\n")
+		end
+
+		-- Set default values, this automatically handles the 0 case
+		body:Push("local mantissa, exponent, sign = 0, 0, 0")
+
+		-- Handle infinity
+		if width ~= 64 then
+			local maxValue = (2 - 2 ^ -mantissaWidth) * 2 ^ (exponentBias + 1)
+			body:Push("if math.abs(value) > ", maxValue, " then")
+		else
+			body:Push("if math.abs(value) >= math.huge then")
+		end
+		body:Push("\texponent, sign = ", exponentMax, ", if value < 0 then 1 else 0")
+
+		-- Handle NaN
+		body:Push("elseif value ~= value then")
+		body:Push("\tmantissa, exponent, sign = 1, ", exponentMax, ", 1")
+
+		-- Handle everything else
+		body:Push("elseif value ~= 0 then")
+		body:Push("\tlocal absValue = math.abs(value)")
+
+		-- Round the value to the nearest epsilon, only for halfs and singles, since
+		-- luau numbers are already doubles, so it would just yield the same result
+		if width ~= 64 then
+			local min = "math.floor(math.log(absValue, 2))"
+			body:Push("\tlocal interval = math.ldexp(1, ", min, " - ", mantissaWidth, ")")
+			body:Push("\tvalue = math.round(value / interval) * interval\n")
+		end
+
+		body:Push("\tmantissa, exponent = math.frexp(absValue)")
+		body:Push("\texponent += ", exponentBias, "\n")
+		body:Push("\tmantissa = math.round(if exponent <= 0")
+		body:Push("\t\tthen mantissa * ", tohex(2 ^ mantissaWidth), " / math.ldexp(1, math.abs(exponent))")
+		body:Push("\t\telse mantissa * ", tohex(2 ^ (mantissaWidth + 1)), ")")
+		body:Push("\texponent = math.max(exponent, 0)")
+		body:Push("\tsign = if value < 0 then 1 else 0")
+		body:Push("end\n")
+
+		-- Write the values to the buffer
+		body:Push("bitbuffer.writeu", mantissaWidth, "(b, offset, mantissa)")
+		body:Push("bitbuffer.writeu", exponentWidth, "(b, offset + ", mantissaWidth, ", exponent)")
+		body:Push("bitbuffer.writeu1(b, offset + ", mantissaWidth + exponentWidth, ", sign)")
+
+		body:Indent()
+
+		body:Insert(1, "--- Writes a ", floatData.name)
+		body:Insert(2, "function bitbuffer.writef", width, "(b: buffer, offset: number, value: number)")
+
 		body:Push("end")
 
 		table.insert(output, tostring(body))

--- a/src/init.luau
+++ b/src/init.luau
@@ -1926,23 +1926,22 @@ do -- float
 	do -- write
 		--- Writes a Half-precision IEEE 754 number
 		function bitbuffer.writef16(b: buffer, offset: number, value: number)
-			if offset % 8 == 0 then
-				buffer.writef16(b, offset // 8, value)
-				return
-			end
-
 			local mantissa, exponent, sign = 0, 0, 0
 			if math.abs(value) > 65504 then
 				exponent, sign = 0b11111, if value < 0 then 1 else 0
 			elseif value ~= value then
 				mantissa, exponent, sign = 1, 0b11111, 1
 			elseif value ~= 0 then
-				mantissa, exponent = math.frexp(value)
+				local absValue = math.abs(value)
+				local interval = math.ldexp(1, math.floor(math.log(absValue, 2)) - 10)
+				value = math.round(value / interval) * interval
+
+				mantissa, exponent = math.frexp(absValue)
 				exponent += 14
 
 				mantissa = math.round(if exponent <= 0
-					then math.abs(mantissa) * 0x400 / math.ldexp(1, math.abs(exponent))
-					else math.abs(mantissa) * 0x800)
+					then mantissa * 0x400 / math.ldexp(1, math.abs(exponent))
+					else mantissa * 0x800)
 				exponent = math.max(exponent, 0)
 				sign = if value < 0 then 1 else 0
 			end
@@ -1965,12 +1964,16 @@ do -- float
 			elseif value ~= value then
 				mantissa, exponent, sign = 1, 0b11111111, 1
 			elseif value ~= 0 then
-				mantissa, exponent = math.frexp(value)
+				local absValue = math.abs(value)
+				local interval = math.ldexp(1, math.floor(math.log(absValue, 2)) - 23)
+				value = math.round(value / interval) * interval
+
+				mantissa, exponent = math.frexp(absValue)
 				exponent += 126
 
 				mantissa = math.round(if exponent <= 0
-					then math.abs(mantissa) * 0x800000 / math.ldexp(1, math.abs(exponent))
-					else math.abs(mantissa) * 0x1000000)
+					then mantissa * 0x800000 / math.ldexp(1, math.abs(exponent))
+					else mantissa * 0x1000000)
 				exponent = math.max(exponent, 0)
 				sign = if value < 0 then 1 else 0
 			end
@@ -1988,17 +1991,18 @@ do -- float
 			end
 
 			local mantissa, exponent, sign = 0, 0, 0
-			if math.abs(value) > 1.7976931348623157e+308 then
+			if math.abs(value) >= math.huge then
 				exponent, sign = 0b11111111111, if value < 0 then 1 else 0
 			elseif value ~= value then
 				mantissa, exponent, sign = 1, 0b11111111111, 1
 			elseif value ~= 0 then
-				mantissa, exponent = math.frexp(value)
+				local absValue = math.abs(value)
+				mantissa, exponent = math.frexp(absValue)
 				exponent += 1022
 
 				mantissa = math.round(if exponent <= 0
-					then math.abs(mantissa) * 0x10000000000000 / math.ldexp(1, math.abs(exponent))
-					else math.abs(mantissa) * 0x20000000000000)
+					then mantissa * 0x10000000000000 / math.ldexp(1, math.abs(exponent))
+					else mantissa * 0x20000000000000)
 				exponent = math.max(exponent, 0)
 				sign = if value < 0 then 1 else 0
 			end
@@ -2012,10 +2016,6 @@ do -- float
 	do -- read
 		--- Reads a Half-precision IEEE 754 number
 		function bitbuffer.readf16(b: buffer, offset: number): number
-			if offset % 8 == 0 then
-				return buffer.readf16(b, offset // 8)
-			end
-
 			local mantissa = bitbuffer.readu10(b, offset)
 			local exponent = bitbuffer.readu5(b, offset + 10)
 			local sign = bitbuffer.readu1(b, offset + 15) == 1
@@ -2038,9 +2038,9 @@ do -- float
 
 		--- Reads a Single-precision IEEE 754 number
 		function bitbuffer.readf32(b: buffer, offset: number): number
-			if offset % 8 == 0 then
-				return buffer.readf32(b, offset // 8)
-			end
+				if offset % 8 == 0 then
+					return buffer.readf32(b, offset // 8)
+				end
 
 			local mantissa = bitbuffer.readu23(b, offset)
 			local exponent = bitbuffer.readu8(b, offset + 23)
@@ -2064,9 +2064,9 @@ do -- float
 
 		--- Reads a Double-precision IEEE 754 number
 		function bitbuffer.readf64(b: buffer, offset: number): number
-			if offset % 8 == 0 then
-				return buffer.readf64(b, offset // 8)
-			end
+				if offset % 8 == 0 then
+					return buffer.readf64(b, offset // 8)
+				end
 
 			local mantissa = bitbuffer.readu52(b, offset)
 			local exponent = bitbuffer.readu11(b, offset + 52)

--- a/src/init.luau
+++ b/src/init.luau
@@ -3,7 +3,7 @@
 --!strict
 
 -- stylua: ignore start
--- @diagnostic disable: undefined-type
+---@diagnostic disable: undefined-type
 
 local readu8 = buffer.readu8
 local readu16 = buffer.readu16


### PR DESCRIPTION
Due to values like `3.999997` being representable as a double, `math.frexp` would return a fraction and exponent not representable by singles and halfs.

The solution is to round the input value to the nearest representable value (by rounding it to the nearest epsilon)